### PR TITLE
Change course command to use beta.cmucourses.com instead

### DIFF
--- a/commands/course.yml
+++ b/commands/course.yml
@@ -8,8 +8,8 @@ matches:
   - fces
   - units
   - curse
-searchUrl: https://cmucourses.com/course/
-home: https://cmucourses.com
+searchUrl: https://beta.cmucourses.com/search?q=
+home: https://beta.cmucourses.com
 examples:
   - fce
   - fce 122


### PR DESCRIPTION
Course Tool beta now redirects `/search?q=` correctly, so this uses that instead.