### PR TITLE
Fixes typo in `name` field of pokes config

### DIFF
--- a/commands/pokes.yml
+++ b/commands/pokes.yml
@@ -1,4 +1,4 @@
-Name: Pokes
+name: Pokes
 description: Redirect to Facebook Pokes.
 author: rgodse
 matches:


### PR DESCRIPTION
Fixes case error in pr #30 that prevents pokes command name from rendering on help page