### PR TITLE
Create define command

### DIFF
--- a/commands/define.yml
+++ b/commands/define.yml
@@ -1,0 +1,10 @@
+name: Define
+description: Redirect to Oxford English Dictionary. Include the word in the query to go to the right definition page.
+author: kaitlyncliu
+matches:
+  - define
+searchUrl: https://www.oed.com/search?searchType=dictionary&q=
+home: https://www.oed.com/
+examples:
+  - define
+  - define petrichor


### PR DESCRIPTION
Redirects to Oxford English Dictionary

# Description

This creates a command to search the Oxford English Dictionary using `define` or `define query`.
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #43 

## Type of change

<!-- Please delete options that are not relevant. -->
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Ran the commands list page on localhost and checked that the commands correctly redirect.
