### PR TITLE
fix to Next issue of char escaping

### DIFF
--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -7,12 +7,13 @@ export default function NoobPage() {
 
 export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
-  const { q } = ctx.query;
+  let q = ctx.req['url'];
   if (typeof q !== 'string') return { notFound: true };
+  q = decodeURIComponent(q.replace('/noob?q=', ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();
-  const query = match[2];
+  const query = encodeURIComponent(match[2]);
   const config = mapping[token];
   const home = config?.home;
   const searchUrl = config?.searchUrl;
@@ -22,7 +23,7 @@ export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
     return { redirect: { destination: target, permanent: true } };
   return {
     redirect: {
-      destination: `https://google.com/search?q=${q}`,
+      destination: `https://google.com/search?q=${encodeURIComponent(q)}`,
       permanent: false
     }
   };

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -7,6 +7,8 @@ export default function NoobPage() {
 
 export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
+  console.log(ctx.req.url);
+  console.log(ctx.resolvedUrl);
   let q = ctx.req.url;
   if (typeof q !== 'string') return { notFound: true };
   q = decodeURIComponent(q.replace(/^[^_]*=/, ''));

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -9,7 +9,7 @@ export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
   let q = ctx.req.url;
   if (typeof q !== 'string') return { notFound: true };
-  q = decodeURIComponent(q.replace('/noob?q=', ''));
+  q = decodeURIComponent(q.replace(/^[^_]*=/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -8,7 +8,6 @@ export default function NoobPage() {
 export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
   let q = ctx.req.url;
-  console.log(q);
   if (typeof q !== 'string') return { notFound: true };
   q = decodeURIComponent(q.replace('/noob?q=', ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -7,11 +7,9 @@ export default function NoobPage() {
 
 export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
-  console.log(ctx.req.url);
-  console.log(ctx.resolvedUrl);
-  let q = ctx.req.url;
-  if (typeof q !== 'string') return { notFound: true };
-  q = decodeURIComponent(q.replace(/^[^_]*=/, ''));
+  const { url } = ctx.req;
+  if (typeof url !== 'string') return { notFound: true };
+  const q = decodeURIComponent(url.replace(/^[^_]*=/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -9,7 +9,7 @@ export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
   const { url } = ctx.req;
   if (typeof url !== 'string') return { notFound: true };
-  const q = url.replace(/^[^_]*=/, '').replaceAll('=', '');
+  const q = decodeURIComponent(url.replace(/^[^=]+[=]*/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -9,7 +9,7 @@ export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
   const { url } = ctx.req;
   if (typeof url !== 'string') return { notFound: true };
-  const q = decodeURIComponent(url.replace(/^[^_]*=/, ''));
+  const q = url.replace(/^[^_]*=/, '').replaceAll('=', '');
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -7,18 +7,19 @@ export default function NoobPage() {
 
 export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
-  const { url } = ctx.req;
-  if (typeof url !== 'string') return { notFound: true };
-  const q = decodeURIComponent(url.replace(/^[^=]+[=]*/, ''));
+  const { q } = ctx.query;
+  if (typeof q !== 'string') return { notFound: true };
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();
-  const query = encodeURIComponent(match[2]);
+  const query = match[2];
   const config = mapping[token];
   const home = config?.home;
   const searchUrl = config?.searchUrl;
   const target =
-    searchUrl === undefined || query === undefined ? home : searchUrl + query;
+    searchUrl === undefined || query === undefined
+      ? home
+      : searchUrl + encodeURIComponent(query);
   if (isValidUrl(target))
     return { redirect: { destination: target, permanent: true } };
   return {

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -7,7 +7,7 @@ export default function NoobPage() {
 
 export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
-  let q = ctx.req['url'];
+  let q = ctx.req.url;
   if (typeof q !== 'string') return { notFound: true };
   q = decodeURIComponent(q.replace('/noob?q=', ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);

--- a/src/pages/noob.tsx
+++ b/src/pages/noob.tsx
@@ -8,6 +8,7 @@ export default function NoobPage() {
 export const getServerSideProps: GetServerSideProps<{}> = async (ctx) => {
   const { mapping } = readCommands();
   let q = ctx.req.url;
+  console.log(q);
   if (typeof q !== 'string') return { notFound: true };
   q = decodeURIComponent(q.replace('/noob?q=', ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { mapping } = readCommands();
   let q = ctx.req.url;
   if (typeof q !== 'string') return { notFound: true };
-  q = decodeURIComponent(q.replace('/search?q=', ''));
+  q = decodeURIComponent(q.replace(/^[^_]*=/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -68,7 +68,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   return {
     props: {
       query: `${closest}${currQuery}`,
-      currSearch: q
+      currSearch: query
     }
   };
 };

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -48,11 +48,8 @@ export default function SearchPage({ query, currSearch }: Props) {
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { mapping } = readCommands();
-  let q = ctx.req.url;
-  console.log(ctx.resolvedUrl);
-  console.log(ctx.req);
+  const { q } = ctx.query;
   if (typeof q !== 'string') return { notFound: true };
-  q = decodeURIComponent(q.replace(/^[^_]*=/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();
@@ -66,7 +63,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
     return { redirect: { destination: target, permanent: true } };
 
   const closest = closestMatch(token, Object.keys(mapping));
-  const currQuery = query ? ` ${query}` : '';
+  const currQuery = match[2] ? ` ${match[2]}` : '';
   return {
     props: {
       query: `${closest}${currQuery}`,

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -48,7 +48,9 @@ export default function SearchPage({ query, currSearch }: Props) {
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { mapping } = readCommands();
-  let q = ctx.resolvedUrl;
+  let q = ctx.req.url;
+  console.log(ctx.resolvedUrl);
+  console.log(ctx.req);
   if (typeof q !== 'string') return { notFound: true };
   q = decodeURIComponent(q.replace(/^[^_]*=/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -53,12 +53,14 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();
-  const query = encodeURIComponent(match[2]);
+  const query = match[2];
   const config = mapping[token];
   const home = config?.home;
   const searchUrl = config?.searchUrl;
   const target =
-    searchUrl === undefined || query === undefined ? home : searchUrl + query;
+    searchUrl === undefined || query === undefined
+      ? home
+      : searchUrl + encodeURIComponent(query);
   if (isValidUrl(target))
     return { redirect: { destination: target, permanent: true } };
 

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -48,12 +48,13 @@ export default function SearchPage({ query, currSearch }: Props) {
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { mapping } = readCommands();
-  const { q } = ctx.query;
+  let q = ctx.req['url'];
   if (typeof q !== 'string') return { notFound: true };
+  q = decodeURIComponent(q.replace('/search?q=', ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();
-  const query = match[2];
+  const query = encodeURIComponent(match[2]);
   const config = mapping[token];
   const home = config?.home;
   const searchUrl = config?.searchUrl;
@@ -63,7 +64,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
     return { redirect: { destination: target, permanent: true } };
 
   const closest = closestMatch(token, Object.keys(mapping));
-  const currQuery = match[2] ? ` ${match[2]}` : '';
+  const currQuery = query ? ` ${query}` : '';
   return {
     props: {
       query: `${closest}${currQuery}`,

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { mapping } = readCommands();
   let q = ctx.req.url;
   if (typeof q !== 'string') return { notFound: true };
-  q = decodeURIComponent(q.replace(/^[^_]*=/, ''));
+  q = decodeURI(q.replace(/^[^_]*=/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();
@@ -68,7 +68,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   return {
     props: {
       query: `${closest}${currQuery}`,
-      currSearch: query
+      currSearch: q
     }
   };
 };

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -48,7 +48,7 @@ export default function SearchPage({ query, currSearch }: Props) {
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { mapping } = readCommands();
-  let q = ctx.req['url'];
+  let q = ctx.req.url;
   if (typeof q !== 'string') return { notFound: true };
   q = decodeURIComponent(q.replace('/search?q=', ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { mapping } = readCommands();
   let q = ctx.req.url;
   if (typeof q !== 'string') return { notFound: true };
-  q = decodeURI(q.replace(/^[^_]*=/, ''));
+  q = decodeURIComponent(q.replace(/^[^_]*=/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);
   if (match === null) return { notFound: true };
   const token = match[1].toLowerCase();

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -48,7 +48,7 @@ export default function SearchPage({ query, currSearch }: Props) {
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { mapping } = readCommands();
-  let q = ctx.req.url;
+  let q = ctx.resolvedUrl;
   if (typeof q !== 'string') return { notFound: true };
   q = decodeURIComponent(q.replace(/^[^_]*=/, ''));
   const match = q.match(/^(\S*)(?:\s(.*))?$/);


### PR DESCRIPTION
# Description
Encodes query (both noob and normal) and default redirect (noob)
Closes #48, #54, #62

# Type of change
[x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested on localhost for both normal and noob mode `g C++`, `C++`, `h&m`


