### PR TITLE
Add OpenSearch description

### DIFF
--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -2,5 +2,5 @@
                        xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>scotty.lol</ShortName>
   <Description>Scottylol is an exciting search tool for CMU. It is ScottyLabs' implementation of Facebook's internal bunnylol search tool.</Description>
-  <Url type="text/html" template="https://scotty.lol/search?q={searchTerm}"/>
+  <Url type="text/html" template="https://scotty.lol/search?q={searchTerms}"/>
 </OpenSearchDescription>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,6 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>scotty.lol</ShortName>
+  <Description>Scottylol is an exciting search tool for CMU. It is ScottyLabs' implementation of Facebook's internal bunnylol search tool.</Description>
+  <Url type="text/html" template="https://scotty.lol/search?q={searchTerm}"/>
+</OpenSearchDescription>

--- a/public/opensearch_noob.xml
+++ b/public/opensearch_noob.xml
@@ -1,0 +1,6 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>scotty.lol-noob</ShortName>
+  <Description>A noob-friendly version of scotty.lol. Designed for users accustomed to using Google search from search bar. Redirects to Google search if search terms do not match a scotty.lol command.</Description>
+  <Url type="text/html" template="https://scotty.lol/noob?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -22,6 +22,12 @@ class MyDocument extends Document {
           title="scotty.lol"
           href="/opensearch.xml"
         />
+        <link
+          rel="search"
+          type="application/opensearchdescription+xml"
+          title="scotty.lol-noob"
+          href="/opensearch_noob.xml"
+        />
 
         {/* Browser Metadata */}
         <title>ScottyLOL</title>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,6 +15,13 @@ class MyDocument extends Document {
           href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@300&display=swap"
           rel="stylesheet"
         />
+        {/* Autodiscovery for Firefox */}
+        <link
+          rel="search"
+          type="application/opensearchdescription+xml"
+          title="scotty.lol"
+          href="/opensearch.xml" />
+
 
         {/* Browser Metadata */}
         <title>ScottyLOL</title>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -20,8 +20,8 @@ class MyDocument extends Document {
           rel="search"
           type="application/opensearchdescription+xml"
           title="scotty.lol"
-          href="/opensearch.xml" />
-
+          href="/opensearch.xml"
+        />
 
         {/* Browser Metadata */}
         <title>ScottyLOL</title>


### PR DESCRIPTION
# Description

Adds an OpenSearch specification which allows to easily add scotty.lol as a search engine in Firefox

Closes #79 

To test:
- Open the deployment in Firefox
- Right click the search bar
- You should see an option to add scotty.lol (UPD: should also see a noob version)
![image](https://user-images.githubusercontent.com/42977183/225700744-231a234d-9fc0-423e-be45-68facf723c00.png)
- Select the option
- Go to settings and verify that scotty.lol is added to the list of browsers
- Set it as default
- Verify that search works

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update